### PR TITLE
Add basic Express backend and integrate with frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # ExponentialScape
 
-A minimal monorepo with a Next.js frontend. This repository demonstrates a simple setup using pnpm workspaces.
+A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces.
 
 ## Development
 
-Install dependencies and run the development server:
+Install dependencies and run the development servers:
 
 ```bash
 pnpm install
 pnpm dev
 ```
+
+The frontend runs on [http://localhost:3000](http://localhost:3000) and the backend API is available at [http://localhost:3001/api/hello](http://localhost:3001/api/hello).

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(cors());
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from the backend!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend running on http://localhost:${PORT}`);
+});

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "backend",
+  "private": true,
+  "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,8 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 export default function Page() {
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    fetch("http://localhost:3001/api/hello")
+      .then((res) => res.json())
+      .then((data) => setMessage(data.message))
+      .catch((err) => console.error(err));
+  }, []);
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
       <h1 className="text-4xl font-bold">Welcome to ExponentialScape</h1>
       <p className="mt-4">Your analytics and collaboration platform.</p>
+      {message && <p className="mt-2 text-sm text-gray-600">{message}</p>}
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "private": true,
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev": "pnpm --filter frontend dev",
+    "dev": "concurrently \"pnpm --filter backend dev\" \"pnpm --filter frontend dev\"",
     "build": "pnpm --filter frontend build",
-    "start": "pnpm --filter frontend start"
+    "start": "concurrently \"pnpm --filter backend start\" \"pnpm --filter frontend start\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add an Express backend with a simple `/api/hello` endpoint
- use `concurrently` to run both servers
- update Next.js page to fetch from backend
- document backend details in README

## Testing
- `pnpm --filter frontend build`
- `pnpm --filter backend start`

------
https://chatgpt.com/codex/tasks/task_e_6841859482208331b7813cca363da9a9