### PR TITLE
Add basic analytics and collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # ExponentialScape
 
-A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces.
+A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features.
+
+## Features
+
+- **Analytics:** The backend tracks how many times the homepage has been viewed.
+- **Collaboration:** A simple message board lets visitors leave short messages.
 
 ## Development
 

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -3,15 +3,42 @@ const cors = require('cors');
 const compression = require('compression');
 const helmet = require('helmet');
 
+let views = 0;
+const messages = [];
+
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+app.use(express.json());
 app.use(cors());
 app.use(compression());
 app.use(helmet());
 
 app.get('/api/hello', (req, res) => {
   res.json({ message: 'Hello from the backend!' });
+});
+
+app.post('/api/views', (req, res) => {
+  views += 1;
+  res.json({ views });
+});
+
+app.get('/api/views', (req, res) => {
+  res.json({ views });
+});
+
+app.get('/api/messages', (req, res) => {
+  res.json({ messages });
+});
+
+app.post('/api/messages', (req, res) => {
+  const { text } = req.body;
+  if (typeof text !== 'string' || !text.trim()) {
+    return res.status(400).json({ error: 'Message text required' });
+  }
+  const message = { id: Date.now(), text: text.trim(), timestamp: new Date().toISOString() };
+  messages.push(message);
+  res.status(201).json(message);
 });
 
 app.listen(PORT, () => {

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,13 +1,22 @@
 export const dynamic = 'force-dynamic';
 
+import MessageBoard from '../components/MessageBoard';
+
 export default async function Page() {
-  const res = await fetch(`${process.env.API_URL}/api/hello`, { cache: 'no-store' });
-  const data = await res.json();
+  const viewRes = await fetch(`${process.env.API_URL}/api/views`, {
+    method: 'POST',
+    cache: 'no-store',
+  });
+  const { views } = await viewRes.json();
+  const helloRes = await fetch(`${process.env.API_URL}/api/hello`, { cache: 'no-store' });
+  const hello = await helloRes.json();
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
       <h1 className="text-4xl font-bold">Welcome to ExponentialScape</h1>
       <p className="mt-4">Your analytics and collaboration platform.</p>
-      {data.message && <p className="mt-2 text-sm text-gray-600">{data.message}</p>}
+      <p className="mt-2 text-sm text-gray-600">Page views: {views}</p>
+      {hello.message && <p className="mt-2 text-sm text-gray-600">{hello.message}</p>}
+      <MessageBoard />
     </main>
   );
 }

--- a/apps/frontend/components/MessageBoard.tsx
+++ b/apps/frontend/components/MessageBoard.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useEffect, useState, FormEvent } from 'react'
+
+interface Message {
+  id: number
+  text: string
+  timestamp: string
+}
+
+export default function MessageBoard() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    fetch(`${process.env.API_URL}/api/messages`).then(res => res.json()).then(data => {
+      setMessages(data.messages)
+    })
+  }, [])
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!text.trim()) return
+    const res = await fetch(`${process.env.API_URL}/api/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    })
+    if (res.ok) {
+      const msg = await res.json()
+      setMessages(prev => [...prev, msg])
+      setText('')
+    }
+  }
+
+  return (
+    <section className="w-full max-w-md mt-8">
+      <h2 className="text-xl font-semibold mb-2">Message Board</h2>
+      <form onSubmit={submit} className="flex gap-2">
+        <input
+          className="flex-1 border rounded px-2 py-1"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder="Write a message"
+        />
+        <button className="bg-blue-500 text-white px-3 py-1 rounded" type="submit">
+          Send
+        </button>
+      </form>
+      <ul className="mt-4 space-y-2">
+        {messages.map(m => (
+          <li key={m.id} className="border p-2 rounded">
+            <div>{m.text}</div>
+            <div className="text-xs text-gray-500">
+              {new Date(m.timestamp).toLocaleString()}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- implement view counter and message board endpoints in backend
- add a new `MessageBoard` React component
- display view count and message board on homepage
- document new features in README

## Testing
- `pnpm build` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68418822409883318833fa8dc1dcfa7d