### PR TITLE
Improve message board with likes

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -36,9 +36,19 @@ app.post('/api/messages', (req, res) => {
   if (typeof text !== 'string' || !text.trim()) {
     return res.status(400).json({ error: 'Message text required' });
   }
-  const message = { id: Date.now(), text: text.trim(), timestamp: new Date().toISOString() };
+  const message = { id: Date.now(), text: text.trim(), timestamp: new Date().toISOString(), likes: 0 };
   messages.push(message);
   res.status(201).json(message);
+});
+
+app.post('/api/messages/:id/like', (req, res) => {
+  const id = Number(req.params.id);
+  const message = messages.find(m => m.id === id);
+  if (!message) {
+    return res.status(404).json({ error: 'Message not found' });
+  }
+  message.likes += 1;
+  res.json(message);
 });
 
 app.listen(PORT, () => {

--- a/apps/frontend/components/MessageBoard.tsx
+++ b/apps/frontend/components/MessageBoard.tsx
@@ -5,11 +5,20 @@ interface Message {
   id: number
   text: string
   timestamp: string
+  likes: number
 }
 
 export default function MessageBoard() {
   const [messages, setMessages] = useState<Message[]>([])
   const [text, setText] = useState('')
+
+  const like = async (id: number) => {
+    const res = await fetch(`${process.env.API_URL}/api/messages/${id}/like`, { method: 'POST' })
+    if (res.ok) {
+      const updated = await res.json()
+      setMessages(prev => prev.map(m => (m.id === id ? updated : m)))
+    }
+  }
 
   useEffect(() => {
     fetch(`${process.env.API_URL}/api/messages`).then(res => res.json()).then(data => {
@@ -48,11 +57,18 @@ export default function MessageBoard() {
       </form>
       <ul className="mt-4 space-y-2">
         {messages.map(m => (
-          <li key={m.id} className="border p-2 rounded">
+          <li key={m.id} className="border p-2 rounded space-y-1">
             <div>{m.text}</div>
             <div className="text-xs text-gray-500">
               {new Date(m.timestamp).toLocaleString()}
             </div>
+            <button
+              className="text-sm text-blue-600"
+              onClick={() => like(m.id)}
+              type="button"
+            >
+              Like ({m.likes})
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add like feature to backend API
- enable liking messages on the frontend

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6841895809c88331a8364692db62c25a