### PR TITLE
Add navigation layout and new about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExponentialScape
 
-A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features.
+A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features. The site now provides a simple navigation bar and an About page.
 
 ## Features
 

--- a/apps/frontend/app/about/page.tsx
+++ b/apps/frontend/app/about/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic'
+
+export default function AboutPage() {
+  return (
+    <main className="max-w-prose mx-auto p-8">
+      <h1>About ExponentialScape</h1>
+      <p>
+        ExponentialScape is a lightweight platform demonstrating analytics and
+        collaboration features built with Next.js and Express.
+      </p>
+      <p>
+        Explore the message board, view counts and enjoy the simple design
+        enhanced with Tailwind CSS.
+      </p>
+    </main>
+  )
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,6 +1,8 @@
-import '../styles/globals.css';
-import { ReactNode } from 'react';
-import { Inter } from 'next/font/google';
+import '../styles/globals.css'
+import { ReactNode } from 'react'
+import { Inter } from 'next/font/google'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -12,7 +14,11 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={inter.className}>
-      <body>{children}</body>
+      <body className="flex min-h-screen flex-col">
+        <Navbar />
+        <div className="flex-1 container mx-auto p-4">{children}</div>
+        <Footer />
+      </body>
     </html>
-  );
+  )
 }

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Page() {
   const helloRes = await fetch(`${process.env.API_URL}/api/hello`, { cache: 'no-store' });
   const hello = await helloRes.json();
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+    <main className="flex flex-col items-center justify-center p-8 gap-4">
       <h1 className="text-4xl font-bold">Welcome to ExponentialScape</h1>
       <p className="mt-4">Your analytics and collaboration platform.</p>
       <p className="mt-2 text-sm text-gray-600">Page views: {views}</p>

--- a/apps/frontend/components/Footer.tsx
+++ b/apps/frontend/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="mt-12 text-center text-sm text-gray-500 py-4 border-t">
+      <p>
+        &copy; {new Date().getFullYear()} ExponentialScape. All rights reserved.
+      </p>
+    </footer>
+  )
+}

--- a/apps/frontend/components/Navbar.tsx
+++ b/apps/frontend/components/Navbar.tsx
@@ -1,0 +1,15 @@
+'use client'
+import Link from 'next/link'
+
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-800 text-white p-4 flex gap-4">
+      <Link href="/" className="font-semibold hover:underline">
+        Home
+      </Link>
+      <Link href="/about" className="hover:underline">
+        About
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add Navbar and Footer components
- integrate navigation into layout
- create an about page
- tweak homepage styles
- document new navigation in README

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68418a90e90083318000f2d96fd8b338