### PR TITLE
Add backend tests

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -51,6 +51,10 @@ app.post('/api/messages/:id/like', (req, res) => {
   res.json(message);
 });
 
-app.listen(PORT, () => {
-  console.log(`Backend running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Backend running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -12,6 +13,8 @@
     "helmet": "^7.0.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.3"
+    "nodemon": "^3.0.3",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/apps/backend/test/index.test.js
+++ b/apps/backend/test/index.test.js
@@ -1,0 +1,21 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('API', () => {
+  it('responds to GET /api/hello', async () => {
+    const res = await request(app).get('/api/hello');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'Hello from the backend!' });
+  });
+
+  it('creates a message', async () => {
+    const res = await request(app).post('/api/messages').send({ text: 'Test' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.text).toBe('Test');
+  });
+
+  it('rejects empty message', async () => {
+    const res = await request(app).post('/api/messages').send({ text: '' });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app instance for testing
- add Jest & Supertest for backend testing
- create backend tests covering core API

## Testing
- `pnpm --filter backend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68418d9cddd88331953e1842080ea25c