### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # ExponentialScape
 
-A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features. The site now provides a simple navigation bar and an About page.
+A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features. The site now provides a simple navigation bar and an About page. A new dark mode toggle brings the UI in line with modern 2025 design trends.
 
 ## Features
 
 - **Analytics:** The backend tracks how many times the homepage has been viewed.
 - **Collaboration:** A simple message board lets visitors leave short messages.
+- **Dark Mode:** Toggle between light and dark themes to match your preference.
 
 ## Development
 

--- a/apps/frontend/components/Footer.tsx
+++ b/apps/frontend/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="mt-12 text-center text-sm text-gray-500 py-4 border-t">
+    <footer className="mt-12 text-center text-sm text-gray-500 dark:text-gray-400 py-4 border-t dark:border-gray-700">
       <p>
         &copy; {new Date().getFullYear()} ExponentialScape. All rights reserved.
       </p>

--- a/apps/frontend/components/MessageBoard.tsx
+++ b/apps/frontend/components/MessageBoard.tsx
@@ -46,7 +46,7 @@ export default function MessageBoard() {
       <h2 className="text-xl font-semibold mb-2">Message Board</h2>
       <form onSubmit={submit} className="flex gap-2">
         <input
-          className="flex-1 border rounded px-2 py-1"
+          className="flex-1 border rounded px-2 py-1 dark:bg-gray-800 dark:border-gray-700"
           value={text}
           onChange={e => setText(e.target.value)}
           placeholder="Write a message"
@@ -57,13 +57,13 @@ export default function MessageBoard() {
       </form>
       <ul className="mt-4 space-y-2">
         {messages.map(m => (
-          <li key={m.id} className="border p-2 rounded space-y-1">
+          <li key={m.id} className="border p-2 rounded space-y-1 dark:border-gray-700">
             <div>{m.text}</div>
             <div className="text-xs text-gray-500">
               {new Date(m.timestamp).toLocaleString()}
             </div>
             <button
-              className="text-sm text-blue-600"
+              className="text-sm text-blue-600 dark:text-blue-400"
               onClick={() => like(m.id)}
               type="button"
             >

--- a/apps/frontend/components/Navbar.tsx
+++ b/apps/frontend/components/Navbar.tsx
@@ -1,15 +1,17 @@
 'use client'
 import Link from 'next/link'
+import ThemeToggle from './ThemeToggle'
 
 export default function Navbar() {
   return (
-    <nav className="bg-gray-800 text-white p-4 flex gap-4">
+    <nav className="bg-gray-800 text-white dark:bg-gray-900 dark:text-gray-200 p-4 flex gap-4 items-center">
       <Link href="/" className="font-semibold hover:underline">
         Home
       </Link>
       <Link href="/about" className="hover:underline">
         About
       </Link>
+      <ThemeToggle />
     </nav>
   )
 }

--- a/apps/frontend/components/ThemeToggle.tsx
+++ b/apps/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (stored === 'dark' || (!stored && prefersDark)) {
+      document.documentElement.classList.add('dark')
+      setTheme('dark')
+    }
+  }, [])
+
+  const toggle = () => {
+    const next = theme === 'light' ? 'dark' : 'light'
+    setTheme(next)
+    document.documentElement.classList.toggle('dark', next === 'dark')
+    localStorage.setItem('theme', next)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="ml-auto border rounded px-2 py-1 text-sm dark:border-gray-700"
+    >
+      {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+    </button>
+  )
+}

--- a/apps/frontend/styles/globals.css
+++ b/apps/frontend/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html {
+  @apply bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100;
+}

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- integrate dark mode support with Tailwind's class strategy
- add a `ThemeToggle` component and hook it into the navigation bar
- style footer and message board for dark mode
- update global styles and docs

## Testing
- `pnpm --filter backend test`

------
https://chatgpt.com/codex/tasks/task_e_68418eca65d4833185d4811a7c2df177