### PR TITLE
Improve message board with deletion feature

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -52,6 +52,16 @@ app.post('/api/messages/:id/like', (req, res) => {
   res.json(message);
 });
 
+app.delete('/api/messages/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const index = messages.findIndex(m => m.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Message not found' });
+  }
+  const [deleted] = messages.splice(index, 1);
+  res.json(deleted);
+});
+
 app.get('/api/contact', (req, res) => {
   res.json({ contacts });
 });

--- a/apps/backend/test/index.test.js
+++ b/apps/backend/test/index.test.js
@@ -12,6 +12,8 @@ describe('API', () => {
     const res = await request(app).post('/api/messages').send({ text: 'Test' });
     expect(res.statusCode).toBe(201);
     expect(res.body.text).toBe('Test');
+    const del = await request(app).delete(`/api/messages/${res.body.id}`);
+    expect(del.statusCode).toBe(200);
   });
 
   it('rejects empty message', async () => {

--- a/apps/frontend/components/MessageBoard.tsx
+++ b/apps/frontend/components/MessageBoard.tsx
@@ -20,6 +20,13 @@ export default function MessageBoard() {
     }
   }
 
+  const remove = async (id: number) => {
+    const res = await fetch(`${process.env.API_URL}/api/messages/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setMessages(prev => prev.filter(m => m.id !== id))
+    }
+  }
+
   useEffect(() => {
     fetch(`${process.env.API_URL}/api/messages`).then(res => res.json()).then(data => {
       setMessages(data.messages)
@@ -68,6 +75,13 @@ export default function MessageBoard() {
               type="button"
             >
               Like ({m.likes})
+            </button>
+            <button
+              className="text-sm text-red-600 dark:text-red-400 ml-2"
+              onClick={() => remove(m.id)}
+              type="button"
+            >
+              Delete
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- add backend API to delete messages
- support message deletion in MessageBoard UI
- test the delete API

## Testing
- `pnpm install`
- `pnpm --filter backend test`


------
https://chatgpt.com/codex/tasks/task_e_684190a8b4088331bf3915903050cbc9