### PR TITLE
Add metrics page and API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExponentialScape
 
-A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features. The site now provides a simple navigation bar and an About page. A new dark mode toggle brings the UI in line with modern 2025 design trends.
+A minimal monorepo with a Next.js frontend and an Express backend. This repository demonstrates a simple setup using pnpm workspaces and now includes basic analytics and collaboration features. The site now provides a simple navigation bar, an About page and a new Metrics section. A dark mode toggle brings the UI in line with modern 2025 design trends.
 
 ## Features
 
@@ -8,6 +8,7 @@ A minimal monorepo with a Next.js frontend and an Express backend. This reposito
 - **Collaboration:** A simple message board lets visitors leave short messages.
 - **Dark Mode:** Toggle between light and dark themes to match your preference.
 - **Contact Form:** Visitors can send inquiries via the new contact page.
+- **Metrics Page:** View overall page views and trending messages.
 
 ## Development
 

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -43,8 +43,18 @@ app.get('/api/views', (req, res) => {
   res.json({ views });
 });
 
+app.get('/api/metrics', (req, res) => {
+  res.json({ views, messageCount: messages.length });
+});
+
 app.get('/api/messages', (req, res) => {
-  res.json({ messages });
+  let result = [...messages];
+  if (req.query.sort === 'likes') {
+    result.sort((a, b) => b.likes - a.likes);
+  } else if (req.query.sort === 'new') {
+    result.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  }
+  res.json({ messages: result });
 });
 
 app.post('/api/messages', (req, res) => {

--- a/apps/backend/test/index.test.js
+++ b/apps/backend/test/index.test.js
@@ -33,4 +33,24 @@ describe('API', () => {
     const res = await request(app).post('/api/contact').send({});
     expect(res.statusCode).toBe(400);
   });
+
+  it('returns metrics', async () => {
+    await request(app).post('/api/views');
+    const res = await request(app).get('/api/metrics');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('views');
+    expect(res.body).toHaveProperty('messageCount');
+  });
+
+  it('sorts messages by likes', async () => {
+    const first = await request(app).post('/api/messages').send({ text: 'First' });
+    const second = await request(app).post('/api/messages').send({ text: 'Second' });
+    await request(app).post(`/api/messages/${second.body.id}/like`);
+    const res = await request(app).get('/api/messages?sort=likes');
+    expect(res.statusCode).toBe(200);
+    const [top] = res.body.messages;
+    expect(top.id).toBe(second.body.id);
+    await request(app).delete(`/api/messages/${first.body.id}`);
+    await request(app).delete(`/api/messages/${second.body.id}`);
+  });
 });

--- a/apps/frontend/app/metrics/page.tsx
+++ b/apps/frontend/app/metrics/page.tsx
@@ -1,0 +1,24 @@
+export const dynamic = 'force-dynamic'
+
+export default async function MetricsPage() {
+  const metricsRes = await fetch(`${process.env.API_URL}/api/metrics`, { cache: 'no-store' })
+  const { views, messageCount } = await metricsRes.json()
+  const msgsRes = await fetch(`${process.env.API_URL}/api/messages?sort=likes`, { cache: 'no-store' })
+  const { messages } = await msgsRes.json()
+  return (
+    <main className="max-w-prose mx-auto p-8 space-y-4">
+      <h1 className="text-2xl font-semibold">Site Metrics</h1>
+      <p>Page views: {views}</p>
+      <p>Total messages: {messageCount}</p>
+      <h2 className="text-xl font-semibold mt-6">Trending Messages</h2>
+      <ul className="space-y-2">
+        {messages.slice(0, 5).map((m: any) => (
+          <li key={m.id} className="border p-2 rounded flex justify-between dark:border-gray-700">
+            <span>{m.text}</span>
+            <span className="text-sm text-gray-500">Likes: {m.likes}</span>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/apps/frontend/components/Navbar.tsx
+++ b/apps/frontend/components/Navbar.tsx
@@ -14,6 +14,9 @@ export default function Navbar() {
       <Link href="/contact" className="hover:underline">
         Contact
       </Link>
+      <Link href="/metrics" className="hover:underline">
+        Metrics
+      </Link>
       <ThemeToggle />
     </nav>
   )


### PR DESCRIPTION
## Summary
- sort messages by likes or newest on the backend
- expose overall metrics via `/api/metrics`
- add tests for metrics and sorting
- create a Metrics page in the frontend and link it in the navbar
- document the new page in the README

## Testing
- `pnpm install`
- `pnpm --filter backend test`


------
https://chatgpt.com/codex/tasks/task_e_684192d02ee08331a7183cf5116b5856